### PR TITLE
FEAT: Reorganize steps in the CD workflow to enable Cloud Build and C…

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -57,12 +57,12 @@ jobs:
 
     - name: Enable Cloud Build
       run: gcloud services enable cloudbuild.googleapis.com
-
-    - name: Submit Build
-      run: gcloud builds submit --region ${{ secrets.GCP_REGION }} --tag gcr.io/${{ secrets.GCP_PROJECT_ID }}/${{ secrets.GCP_IMAGE_NAME }}:latest    
-
+    
     - name: Enable Cloud Run
       run: gcloud services enable run.googleapis.com
+
+    - name: Submit Build
+      run: gcloud builds submit --region ${{ secrets.GCP_REGION }} --tag gcr.io/${{ secrets.GCP_PROJECT_ID }}/${{ secrets.GCP_IMAGE_NAME }}:latest
 
     - name: Deploy to Cloud Run
       run: gcloud run deploy ${{ secrets.GCP_IMAGE_NAME }} --image gcr.io/${{ secrets.GCP_PROJECT_ID }}/${{ secrets.GCP_IMAGE_NAME }}:latest --region ${{ secrets.GCP_REGION }} --platform managed  --allow-unauthenticated


### PR DESCRIPTION
This update restructures the Continuous Deployment (CD) workflow to include the activation of Cloud Build and Cloud Run services, ensuring a smoother deployment process and reducing potential errors related to missing API configurations.